### PR TITLE
encode payload file in UTF-8 to support non- US-ASCII chars

### DIFF
--- a/lib/iron_worker/version.rb
+++ b/lib/iron_worker/version.rb
@@ -1,5 +1,5 @@
 module IronWorker
-  VERSION = "3.2.2"
+  VERSION = "3.2.3"
 
   def self.version
     VERSION

--- a/lib/iron_worker/worker_helper.rb
+++ b/lib/iron_worker/worker_helper.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This could be a gem to help worker users with common functions like getting config and payload.
 require 'json'
 
@@ -34,8 +35,7 @@ module IronWorker
     # puts "args: #{@@args.inspect}"
 
     if args[:payload_file]
-      @@payload = File.read(@@args[:payload_file])
-
+      @@payload = File.open(@@args[:payload_file], "r:UTF-8", &:read)
       begin
         @@payload = JSON.parse(@@payload)
       rescue => ex


### PR DESCRIPTION
This allows reading non US-ASCII chars in payload.
@treeder this is the message I get: 
"Couldn't parse IronWorker payload into json, leaving as string. "\xE2" on US-ASCII"