### PR TITLE
NameError: undefined local variable or method `rest' for #<IronWorker::APIClient:0x005646ec018d60> 1 File "/mnt/task/bundle/ruby/2.2.0/gems/iron_worker-3.3.0/lib/iron_worker/api_client.rb"

### DIFF
--- a/lib/iron_worker/api_client.rb
+++ b/lib/iron_worker/api_client.rb
@@ -16,7 +16,7 @@ module IronWorker
 
       super('iron', 'worker', options, default_options, [:project_id, :token, :jwt, :api_version])
 
-      IronCore::Logger.debug 'IronWorker', "nhp.proxy: #{rest.wrapper.http.proxy_uri}" if defined? Net::HTTP::Persistent
+      #IronCore::Logger.debug 'IronWorker', "nhp.proxy: #{rest.wrapper.http.proxy_uri}" if defined? Net::HTTP::Persistent
       IronCore::Logger.debug 'IronWorker', "RestClient.proxy: #{RestClient.proxy}" if defined? RestClient
       IronCore::Logger.debug 'IronWorker', "InternalClient.proxy: #{Rest::InternalClient.proxy}" if defined? Rest::InternalClient
 


### PR DESCRIPTION
This line began throwing an error after moving to 3.3.0.  We've reverted to our branch and commented out this line.  Not sure what caused it to suddenly trigger the bug, perhaps Net::HTTP::Persistent became defined.  Either way, __rest__ is not defined in that scope.