### PR TITLE
update iron_core from 0.5.1 to 1.0.9

### DIFF
--- a/iron_worker.gemspec
+++ b/iron_worker.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.required_rubygems_version = ">= 1.3.6"
   gem.required_ruby_version = Gem::Requirement.new(">= 1.9")
-  gem.add_runtime_dependency "iron_core", "~> 0.5", ">= 0.5.1"
+  gem.add_runtime_dependency "iron_core", "~> 1.0", ">= 1.0.9"
   gem.add_runtime_dependency 'rest', '~> 3.0', ">= 3.0.6"
   gem.add_runtime_dependency "json", "~> 1.8", "> 1.8.1"
 


### PR DESCRIPTION
This addresses the issue @cdimartino brings up in #45.

[3.3.0](https://github.com/iron-io/iron_worker_ruby/commit/acdd9ea4be7e10e44b2148da73d458678bd9d8d7) froze iron_core to the 0.5 family. I'm not sure what the reason for this was, but it broke the call to `rest` in [`IronWorker::APIClient.initialize`](https://github.com/iron-io/iron_worker_ruby/blob/master/lib/iron_worker/api_client.rb#L19) as the super [`IronCore::Client`](https://github.com/iron-io/iron_core_ruby/blob/master/lib/iron_core/client.rb) hadn't exposed `rest` until a later version.